### PR TITLE
darken up the "ignored" files

### DIFF
--- a/themes/FlatlandDark-color-theme.json
+++ b/themes/FlatlandDark-color-theme.json
@@ -37,7 +37,7 @@
 		"gitDecoration.deletedResourceForeground": "#FFB454",
 		"gitDecoration.stageDeletedResourceForeground": "#FFB454",
 		"gitDecoration.untrackedResourceForeground": "#72AACA",
-		"gitDecoration.ignoredResourceForeground": "#72AACA",
+		"gitDecoration.ignoredResourceForeground": "#798188",
 		"gitDecoration.conflictingResourceForeground": "#72AACA",
 		"gitDecoration.submoduleResourceForeground": "#72AACA",
 		"breadcrumb.foreground": "#eee",


### PR DESCRIPTION
## Description

I find it confusing that my git ignored files/directories are the same color as my modified files/directories. This change attempts to address that by using a darker color (copied from the GitGutter ignored style).